### PR TITLE
Bump packages, fix MacOS build, add nix-darwin to flake.nix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ add_library(rang-lib
         src/text/color.cpp
         src/text/word.cpp
         src/text/line.cpp
-        src/qt_operators.cpp
         src/utility/trie.cpp
         src/keystroke_parser.cpp
         src/commands/command.cpp

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1714641030,
-        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714763106,
-        "narHash": "sha256-DrDHo74uTycfpAF+/qxZAMlP/Cpe04BVioJb6fdI0YY=",
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9be42459999a253a9f92559b1f5b72e1b44c13d",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
         "type": "github"
       },
       "original": {
@@ -36,14 +36,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1714640452,
-        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         # 3. Add here: foo.flakeModule
 
       ];
-      systems = [ "x86_64-linux" ];
+      systems = [ "x86_64-linux" "aarch64-darwin" ];
       perSystem = { config, self', inputs', pkgs, system, ... }: {
         # Per-system attributes can be defined here. The self' and inputs'
         # module parameters provide easy access to attributes of the same
@@ -29,8 +29,9 @@
             # C++ Compiler is already part of stdenv
             gdb
             cmake
-            llvmPackages_18.clang
+            llvmPackages_20.clang
             qt6.qtbase
+            catch2_3
           ];
         };
       };

--- a/include/buffer/path_buffer.hpp
+++ b/include/buffer/path_buffer.hpp
@@ -3,6 +3,8 @@
 
 #include "buffer.hpp"
 
+#include <filesystem>
+
 /// Most of buffers represent some 'path' in some form.
 class PathBuffer : public Buffer {
     Q_OBJECT

--- a/include/qt_operators.hpp
+++ b/include/qt_operators.hpp
@@ -3,8 +3,6 @@
 
 #include <QList>
 
-std::strong_ordering operator<=>(const QString& left, const QString& right);
-
 template <typename T>
 auto operator<=>(const QList<T>& left, const QList<T>& right) {
   return std::lexicographical_compare_three_way(left.cbegin(), left.cend(), right.cbegin(),

--- a/include/term/terminal.hpp
+++ b/include/term/terminal.hpp
@@ -5,10 +5,8 @@
 
 namespace term {
 
-namespace ios {
 #include <sys/ioctl.h>
 #include <termios.h>
-}  // namespace ios
 
 class terminal_stream {
   private:
@@ -31,7 +29,7 @@ class terminal {
     static int m_width;
     static int m_height;
 
-    ios::termios initial_ios;
+    termios initial_ios;
 
   public:
     static void resize(int);

--- a/src/buffer/text_file_preview_buffer.cpp
+++ b/src/buffer/text_file_preview_buffer.cpp
@@ -1,5 +1,7 @@
 #include "buffer/text_file_preview_buffer.hpp"
 
+#include <filesystem>
+
 void TextFilePreviewBuffer::update() {
   if (status(m_path).type() == std::filesystem::file_type::regular) {
     QFile file(m_path);

--- a/src/qt_operators.cpp
+++ b/src/qt_operators.cpp
@@ -1,5 +1,0 @@
-#include "qt_operators.hpp"
-
-std::strong_ordering operator<=>(const QString& left, const QString& right) {
-  return left.compare(right) <=> 0;
-}

--- a/src/term/terminal.cpp
+++ b/src/term/terminal.cpp
@@ -15,10 +15,10 @@ terminal_stream& terminal_stream::operator<<(std::ostream& (*func)(std::ostream&
 
 terminal::terminal() : stream(std::cout) {
   // disable echo and buffering
-  ios::tcgetattr(fileno(stdout), &initial_ios);
-  ios::termios current = initial_ios;
+  tcgetattr(fileno(stdout), &initial_ios);
+  termios current = initial_ios;
   current.c_lflag &= ~(ECHO | ICANON);
-  ios::tcsetattr(fileno(stdout), TCSANOW, &current);
+  tcsetattr(fileno(stdout), TCSANOW, &current);
 
   // set initial terminal size
   resize(0);
@@ -33,7 +33,7 @@ terminal::~terminal() {
   stream << manip::clear{} << manip::alternate_buffer{false} << manip::cursor{true} << std::flush;
 
   // restore termios
-  ios::tcsetattr(fileno(stdout), TCSANOW, &initial_ios);
+  tcsetattr(fileno(stdout), TCSANOW, &initial_ios);
 }
 
 int terminal::m_width;
@@ -48,8 +48,8 @@ int terminal::height() const {
 }
 
 void terminal::resize(int) {
-  ios::winsize ws;
-  ios::ioctl(1, TIOCGWINSZ, &ws);
+  winsize ws;
+  ioctl(1, TIOCGWINSZ, &ws);
   m_width = ws.ws_col;
   m_height = ws.ws_row;
 }


### PR DESCRIPTION
- Fix some issues with <filesystem> header
- Qt has added the required comparison operators
- Add Catch2 to shell dependencies (for testing purposes)
